### PR TITLE
Enhancement: added box shadow to card on hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,6 +31,11 @@ main {
   align-items: center;
 }
 
+.card:hover {
+  box-shadow: 9px 5px 106px -8px rgba(0, 0, 0, 0.36);
+  transition: all 500ms linear;
+}
+
 .card-img-top {
   object-fit: cover;
   width: 100%;


### PR DESCRIPTION
Added box shadow on hover to the `card`. Please see gif below.

![cat-ard-box-shadow](https://user-images.githubusercontent.com/34847680/135734224-8e72e407-5eee-4ebe-a37d-c56fdc34909e.gif)


